### PR TITLE
feat: add redops web ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,30 @@ python run.py api
 python run.py worker --queue nmap
 curl -H "X-RedOps-Token: changeme" http://127.0.0.1:5000/health
 ```
+
+## UI Development
+
+```bash
+cd webui
+cp .env.example .env
+npm install
+npm run dev
+# open http://127.0.0.1:5173
+```
+
+## Build & Serve via FastAPI
+
+```bash
+cd webui && npm run build
+# restart the API; UI served at http://127.0.0.1:5000/ui
+```
+
+## Usage
+
+```bash
+# run worker for nmap queue
+python run.py worker nmap
+# start API
+python run.py api --host 0.0.0.0 --port 5000
+# UI: npm run dev (proxy) or build then access /ui
+```

--- a/api/main.py
+++ b/api/main.py
@@ -5,6 +5,8 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
 from starlette.responses import JSONResponse
+import os
+from starlette.staticfiles import StaticFiles
 
 from api.routers import dirbusting, knowledge, lfi, nmap, orchestrator, vuln, waf, webrecon
 from core.auth import api_key
@@ -19,6 +21,7 @@ app.add_middleware(SlowAPIMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
+    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"]
 )
@@ -36,3 +39,8 @@ async def health():
     return {"status": "ok"}
 
 instrumentator.instrument(app).expose(app)
+
+# --- Static UI (optionnel) ---
+dist_path = os.path.join(os.path.dirname(__file__), "..", "webui", "dist")
+if os.path.isdir(dist_path):
+    app.mount("/ui", StaticFiles(directory=dist_path, html=True), name="ui")

--- a/webui/.env.example
+++ b/webui/.env.example
@@ -1,0 +1,2 @@
+VITE_API_BASE=http://127.0.0.1:5000/api/v1
+VITE_API_TOKEN=changeme

--- a/webui/index.html
+++ b/webui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="fr" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>RedOps Orchestrator</title>
+  </head>
+  <body class="bg-redops-bg text-gray-100">
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/webui/package.json
+++ b/webui/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "redops2-webui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.7.7",
+    "pinia": "^2.2.6",
+    "socket.io-client": "^4.8.1",
+    "vue": "^3.4.38",
+    "vue-router": "^4.4.5"
+  },
+  "devDependencies": {
+    "@tailwindcss/forms": "^0.5.9",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.13",
+    "vite": "^5.4.8"
+  }
+}

--- a/webui/postcss.config.js
+++ b/webui/postcss.config.js
@@ -1,0 +1,1 @@
+export default { plugins: { tailwindcss: {}, autoprefixer: {} } }

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="min-h-screen flex">
+    <aside class="w-64 bg-redops-card border-r border-gray-800 hidden md:block">
+      <div class="p-4 text-xl font-bold text-red-400">RedOps</div>
+      <nav class="p-2 space-y-1">
+        <RouterLink class="block px-3 py-2 rounded hover:bg-gray-800" to="/">Dashboard</RouterLink>
+        <RouterLink class="block px-3 py-2 rounded hover:bg-gray-800" to="/nmap">Nmap</RouterLink>
+        <RouterLink class="block px-3 py-2 rounded hover:bg-gray-800" to="/webrecon">WebRecon</RouterLink>
+        <RouterLink class="block px-3 py-2 rounded hover:bg-gray-800" to="/vuln">Vuln</RouterLink>
+        <RouterLink class="block px-3 py-2 rounded hover:bg-gray-800" to="/orchestrator">Orchestrator</RouterLink>
+        <RouterLink class="block px-3 py-2 rounded hover:bg-gray-800" to="/settings">Settings</RouterLink>
+      </nav>
+    </aside>
+    <main class="flex-1">
+      <header class="sticky top-0 z-10 bg-redops-card/80 backdrop-blur border-b border-gray-800">
+        <div class="max-w-6xl mx-auto p-3 flex items-center justify-between">
+          <div class="font-semibold">RedOps Orchestrator</div>
+          <div class="text-xs text-gray-400">Dark • Live • OSCP-safe</div>
+        </div>
+      </header>
+      <section class="max-w-6xl mx-auto p-4">
+        <RouterView />
+      </section>
+    </main>
+  </div>
+</template>

--- a/webui/src/api/index.js
+++ b/webui/src/api/index.js
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+const API = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE || 'http://127.0.0.1:5000/api/v1'
+})
+
+API.interceptors.request.use((cfg) => {
+  cfg.headers['X-RedOps-Token'] = import.meta.env.VITE_API_TOKEN || 'changeme'
+  return cfg
+})
+
+export default API

--- a/webui/src/components/JobStatus.vue
+++ b/webui/src/components/JobStatus.vue
@@ -1,0 +1,27 @@
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import API from '../api'
+
+const props = defineProps({ module: String, jobId: String })
+const status = ref('pending')
+const result = ref(null)
+let t = null
+
+async function poll() {
+  const { data } = await API.get(`/${props.module}/scans/${props.jobId}`)
+  status.value = data.status
+  if (data.result) result.value = data.result
+  if (data.status === 'finished' || data.status === 'failed') clearInterval(t)
+}
+
+onMounted(() => { t = setInterval(poll, 1500); poll() })
+onUnmounted(() => t && clearInterval(t))
+</script>
+
+<template>
+  <div class="bg-redops-card p-4 rounded-xl border border-gray-800 mt-3">
+    <div class="text-sm">Job [[ jobId ]] – <span :class="status==='finished'?'text-green-400':status==='failed'?'text-red-400':'text-yellow-400'">[[ status ]]</span></div>
+    <pre v-if="result?.stdout" class="mt-3 p-3 bg-black/40 rounded overflow-auto text-xs">[[ result.stdout ]]</pre>
+    <pre v-if="result?.stderr" class="mt-3 p-3 bg-black/40 rounded overflow-auto text-xs text-red-300">[[ result.stderr ]]</pre>
+  </div>
+</template>

--- a/webui/src/components/ModuleCards.vue
+++ b/webui/src/components/ModuleCards.vue
@@ -1,0 +1,18 @@
+<script setup>
+const modules = [
+  { key: 'nmap', title: 'Nmap', desc: 'TCP/UDP, services, NSE', to: '/nmap' },
+  { key: 'webrecon', title: 'WebRecon', desc: 'Headers, cookies, CORS', to: '/webrecon' },
+  { key: 'vuln', title: 'Vuln', desc: 'Nuclei + Searchsploit', to: '/vuln' },
+  { key: 'orchestrator', title: 'Orchestrator', desc: 'Profils multi-modules', to: '/orchestrator' }
+]
+</script>
+
+<template>
+  <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <RouterLink v-for="m in modules" :key="m.key" :to="m.to"
+      class="bg-redops-card p-5 rounded-xl border border-gray-800 hover:border-red-600 transition">
+      <div class="text-lg font-semibold text-red-400">[[ m.title ]]</div>
+      <div class="text-sm text-gray-400 mt-1">[[ m.desc ]]</div>
+    </RouterLink>
+  </div>
+</template>

--- a/webui/src/components/ScanForm.vue
+++ b/webui/src/components/ScanForm.vue
@@ -1,0 +1,40 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import API from '../api'
+
+const props = defineProps({ module: { type: String, required: true } })
+const target = ref('')
+const profile = ref('')
+const profiles = ref([])
+const busy = ref(false)
+const emit = defineEmits(['created'])
+
+onMounted(async () => {
+  const { data } = await API.get(`/${props.module}/profiles`)
+  profiles.value = data
+  profile.value = data[0] || 'normal'
+})
+
+async function submit() {
+  busy.value = true
+  try {
+    const { data } = await API.post(`/${props.module}/scans`, { target: target.value, profile: profile.value })
+    emit('created', data.job_id)
+  } finally { busy.value = false }
+}
+</script>
+
+<template>
+  <div class="bg-redops-card p-4 rounded-xl border border-gray-800">
+    <div class="grid md:grid-cols-3 gap-3">
+      <input v-model="target" type="text" placeholder="Cible (ex: scanme.nmap.org)" class="bg-black/40 border-gray-700 rounded"/>
+      <select v-model="profile" class="bg-black/40 border-gray-700 rounded">
+        <option v-for="p in profiles" :key="p" :value="p">[[ p ]]</option>
+      </select>
+      <button :disabled="busy || !target" @click="submit"
+        class="bg-redops-accent/20 hover:bg-red-600/30 border border-red-600 rounded px-4">
+        Lancer
+      </button>
+    </div>
+  </div>
+</template>

--- a/webui/src/lib/socket.js
+++ b/webui/src/lib/socket.js
@@ -1,0 +1,11 @@
+import { io } from 'socket.io-client'
+
+// Backend Socket.IO (optionnel). Si pas dispo, on ne crash pas.
+export function makeSocket(url) {
+  try {
+    const s = io(url, { transports: ['websocket'], autoConnect: true })
+    return s
+  } catch {
+    return null
+  }
+}

--- a/webui/src/main.css
+++ b/webui/src/main.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root { --redops-accent: #ff4444; --redops-ok: #00ff99; }

--- a/webui/src/main.js
+++ b/webui/src/main.js
@@ -1,0 +1,10 @@
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import router from './router'
+import App from './App.vue'
+import './main.css'
+
+const app = createApp(App)
+app.use(createPinia())
+app.use(router)
+app.mount('#app')

--- a/webui/src/router/index.js
+++ b/webui/src/router/index.js
@@ -1,0 +1,19 @@
+import { createRouter, createWebHashHistory } from 'vue-router'
+import Dashboard from '../views/Dashboard.vue'
+import Nmap from '../views/Nmap.vue'
+import WebRecon from '../views/WebRecon.vue'
+import Vuln from '../views/Vuln.vue'
+import Orchestrator from '../views/Orchestrator.vue'
+import Settings from '../views/Settings.vue'
+
+export default createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    { path: '/', component: Dashboard },
+    { path: '/nmap', component: Nmap },
+    { path: '/webrecon', component: WebRecon },
+    { path: '/vuln', component: Vuln },
+    { path: '/orchestrator', component: Orchestrator },
+    { path: '/settings', component: Settings }
+  ]
+})

--- a/webui/src/store/app.js
+++ b/webui/src/store/app.js
@@ -1,0 +1,14 @@
+import { defineStore } from 'pinia'
+export const useAppStore = defineStore('app', {
+  state: () => ({
+    token: import.meta.env.VITE_API_TOKEN || 'changeme',
+    apiBase: import.meta.env.VITE_API_BASE || 'http://127.0.0.1:5000/api/v1',
+    notifications: []
+  }),
+  actions: {
+    notify(kind, msg) {
+      this.notifications.push({ id: Date.now(), kind, msg })
+      setTimeout(() => this.notifications.shift(), 5000)
+    }
+  }
+})

--- a/webui/src/views/Dashboard.vue
+++ b/webui/src/views/Dashboard.vue
@@ -1,0 +1,8 @@
+<script setup>
+import ModuleCards from '../components/ModuleCards.vue'
+</script>
+<template>
+  <h1 class="text-2xl font-bold mb-4">Dashboard</h1>
+  <ModuleCards/>
+  <div class="mt-6 text-sm text-gray-400">Metrics: <a class="text-red-400 underline" href="#/settings">configurer le token/API</a></div>
+</template>

--- a/webui/src/views/Nmap.vue
+++ b/webui/src/views/Nmap.vue
@@ -1,0 +1,13 @@
+<script setup>
+import { ref } from 'vue'
+import ScanForm from '../components/ScanForm.vue'
+import JobStatus from '../components/JobStatus.vue'
+const jobId = ref('')
+function onCreated(id){ jobId.value = id }
+</script>
+
+<template>
+  <h1 class="text-2xl font-bold mb-4">Nmap</h1>
+  <ScanForm module="nmap" @created="onCreated"/>
+  <JobStatus v-if="jobId" module="nmap" :job-id="jobId"/>
+</template>

--- a/webui/src/views/Orchestrator.vue
+++ b/webui/src/views/Orchestrator.vue
@@ -1,0 +1,9 @@
+<script setup>
+/* placeholder: future DAG/profile orchestration UI */
+</script>
+<template>
+  <h1 class="text-2xl font-bold mb-4">Orchestrator</h1>
+  <div class="bg-redops-card border border-gray-800 p-4 rounded-xl text-gray-400">
+    À venir: sélection de profil multi-modules, exécution DAG, vue timeline corrélée.
+  </div>
+</template>

--- a/webui/src/views/Settings.vue
+++ b/webui/src/views/Settings.vue
@@ -1,0 +1,14 @@
+<script setup>
+import { useAppStore } from '../store/app'
+const app = useAppStore()
+</script>
+<template>
+  <h1 class="text-2xl font-bold mb-4">Settings</h1>
+  <div class="bg-redops-card p-4 rounded-xl border border-gray-800 space-y-3">
+    <div class="text-sm text-gray-400">Ces champs lisent les variables Vite (rebuild nécessaire pour changer).</div>
+    <div class="grid md:grid-cols-2 gap-3">
+      <div><label class="text-xs">API Base</label><input disabled :value="app.apiBase" class="w-full bg-black/40 border-gray-700 rounded"/></div>
+      <div><label class="text-xs">Token</label><input disabled :value="app.token" class="w-full bg-black/40 border-gray-700 rounded"/></div>
+    </div>
+  </div>
+</template>

--- a/webui/src/views/Vuln.vue
+++ b/webui/src/views/Vuln.vue
@@ -1,0 +1,11 @@
+<script setup>
+import { ref } from 'vue'
+import ScanForm from '../components/ScanForm.vue'
+import JobStatus from '../components/JobStatus.vue'
+const jobId = ref('')
+</script>
+<template>
+  <h1 class="text-2xl font-bold mb-4">Vuln</h1>
+  <ScanForm module="vuln" @created="id => jobId=id"/>
+  <JobStatus v-if="jobId" module="vuln" :job-id="jobId"/>
+</template>

--- a/webui/src/views/WebRecon.vue
+++ b/webui/src/views/WebRecon.vue
@@ -1,0 +1,11 @@
+<script setup>
+import { ref } from 'vue'
+import ScanForm from '../components/ScanForm.vue'
+import JobStatus from '../components/JobStatus.vue'
+const jobId = ref('')
+</script>
+<template>
+  <h1 class="text-2xl font-bold mb-4">WebRecon</h1>
+  <ScanForm module="webrecon" @created="id => jobId=id"/>
+  <JobStatus v-if="jobId" module="webrecon" :job-id="jobId"/>
+</template>

--- a/webui/tailwind.config.js
+++ b/webui/tailwind.config.js
@@ -1,0 +1,19 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{vue,js,ts}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        redops: {
+          bg: '#0b0f14',
+          card: '#121821',
+          accent: '#ff4444',
+          ok: '#00ff99',
+          warn: '#ffcc00'
+        }
+      }
+    }
+  },
+  plugins: [require('@tailwindcss/forms')]
+}

--- a/webui/vite.config.js
+++ b/webui/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+// Proxy dev → backend FastAPI (port 5000)
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': 'http://127.0.0.1:5000',
+      '/metrics': 'http://127.0.0.1:5000',
+      '/health': 'http://127.0.0.1:5000'
+    }
+  },
+  build: { outDir: 'dist' }
+})


### PR DESCRIPTION
## Summary
- scaffold Vite/Vue/Tailwind web UI with reusable scan components
- enable CORS and serve built UI from FastAPI
- document UI development and usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68986238cc28832cbbc371f765980f60