### PR TITLE
feat: add SSE stream for nmap jobs

### DIFF
--- a/api/routers/nmap.py
+++ b/api/routers/nmap.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from apps.nmap.profiles import PROFILES
 from apps.nmap.service import run_scan
 from core.jobs import enqueue, get_job
+from core.events import stream_job_events
 
 router = APIRouter(prefix="/nmap", tags=["nmap"])
 
@@ -27,3 +28,9 @@ async def scan_status(job_id: str):
     if not job:
         return {"status": "unknown"}
     return {"status": job.get_status(), "result": job.result}
+
+
+@router.get("/streams/{job_id}")
+async def scan_stream(job_id: str):
+    """Server-sent events stream for job status."""
+    return stream_job_events(job_id, "nmap")

--- a/core/events.py
+++ b/core/events.py
@@ -1,0 +1,64 @@
+import asyncio
+import datetime as dt
+import json
+
+from fastapi.responses import StreamingResponse
+
+from .jobs import get_job
+
+
+def _format(event: str, payload: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(payload)}\n\n"
+
+
+def stream_job_events(job_id: str, queue_name: str) -> StreamingResponse:
+    """Return a StreamingResponse yielding job status events.
+
+    This function polls the RQ job status and emits SSE messages whenever the
+    status changes. It also gracefully handles connection errors or missing jobs
+    so that the stream always yields at least one event.
+    """
+
+    async def event_generator():
+        status_map = {
+            "queued": "job_queued",
+            "started": "job_started",
+            "finished": "job_finished",
+            "failed": "job_failed",
+        }
+        prev_status = None
+        while True:
+            try:
+                job = get_job(job_id, queue_name)
+            except Exception as exc:  # pragma: no cover - redis not available
+                now = dt.datetime.utcnow().isoformat()
+                payload = {
+                    "event": "job_failed",
+                    "timestamp": now,
+                    "data": {"error": str(exc)},
+                }
+                yield _format("job_failed", payload)
+                break
+            if job is None:
+                now = dt.datetime.utcnow().isoformat()
+                payload = {"event": "job_not_found", "timestamp": now, "data": {}}
+                yield _format("job_not_found", payload)
+                break
+            status = job.get_status()
+            if status != prev_status:
+                event = status_map.get(status, "progress")
+                now = dt.datetime.utcnow().isoformat()
+                data = {
+                    "event": event,
+                    "timestamp": now,
+                    "data": {"status": status},
+                }
+                if status == "finished":
+                    data["data"]["result"] = job.result
+                yield _format(event, data)
+                prev_status = status
+                if status in {"finished", "failed"}:
+                    break
+            await asyncio.sleep(1)
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/tests/unit/test_nmap_stream.py
+++ b/tests/unit/test_nmap_stream.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+client = TestClient(app)
+
+
+def test_nmap_stream_endpoint_returns_event():
+    resp = client.get(
+        "/api/v1/nmap/streams/nonexistent",
+        headers={"X-RedOps-Token": "changeme"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert "event:" in resp.text


### PR DESCRIPTION
## Summary
- stream RQ job status updates as server-sent events
- expose `/api/v1/nmap/streams/{job_id}` endpoint
- test stream endpoint

## Testing
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_6899010bd24c832c81617597d2627208